### PR TITLE
Bill number -> bill id

### DIFF
--- a/src/commands/bill/add.js
+++ b/src/commands/bill/add.js
@@ -2,7 +2,7 @@ const database = require('../../database');
 const legiscan = require('../../services/legiscan');
 
 exports.handle = async function(args, message, client) {
-  const billId = args[0];
+  const billId = args.join(' ');
 
   if (billId) {
     const bill = await legiscan.getBill(billId);

--- a/src/services/legiscan.js
+++ b/src/services/legiscan.js
@@ -8,6 +8,29 @@ const endpoint = 'https://api.legiscan.com';
 const sortBills = bills => bills.sort((a, b) => b.history[0].timestamp - a.history[0].timestamp);
 
 exports.getBill = async function(id) {
+  // A bill number was passed in instead of an id
+  if (id.includes(' ')) {
+    const result = await axios.get(endpoint, {
+      params: {
+        key: credentials.key,
+        op: 'search',
+        query: id.split(' ')[1],
+        state: parser.state(id.split(' ')[0]),
+        year: 1
+      }
+    });
+
+    const response = result.data;
+
+    if (result.status === 'OK') {
+      console.log(response);
+    } else {
+      logger.error('API error:');
+      logger.error(response.searchresult);
+      return null;
+    }
+  }
+
   const result = await axios.get(endpoint, {
     params: {
       key: credentials.key,
@@ -34,11 +57,11 @@ exports.getBill = async function(id) {
       })
     };
     return returnBill;
+  } else {
+    logger.error('API error:');
+    logger.error(response);
+    return null;
   }
-
-  logger.error('API error:');
-  logger.error(response);
-  return null;
 };
 
 exports.search = async function(state, query) {


### PR DESCRIPTION
This is problematic because many bills can share the same bill number (i.e. HB2279) but the bill number is needed for `getBill` api