### PR TITLE
Fix: Adding robustness to the bill and config handler's

### DIFF
--- a/src/commands/bill/handler.js
+++ b/src/commands/bill/handler.js
@@ -26,7 +26,12 @@ const canDoCommand = (command, message) => {
 };
 
 exports.handle = function(args, message, client) {
-  const handler = args.shift().toLowerCase();
+  const arg = args.shift();
+  if (!arg) {
+    help.handle(args, message, client);
+    return;
+  }
+  const handler = arg.toLowerCase();
 
   if (!canDoCommand(handler, message)) {
     const notAllowedMsg = `You are not allowed to use the command \`${handler}\`.`;

--- a/src/commands/bill/handler.js
+++ b/src/commands/bill/handler.js
@@ -26,12 +26,7 @@ const canDoCommand = (command, message) => {
 };
 
 exports.handle = function(args, message, client) {
-  const arg = args.shift();
-  if (!arg) {
-    help.handle(args, message, client);
-    return;
-  }
-  const handler = arg.toLowerCase();
+  const handler = (args.shift() || "").toLowerCase();
 
   if (!canDoCommand(handler, message)) {
     const notAllowedMsg = `You are not allowed to use the command \`${handler}\`.`;

--- a/src/commands/config/handler.js
+++ b/src/commands/config/handler.js
@@ -27,12 +27,7 @@ const canDoCommand = (command, message) => {
 };
 
 exports.handle = function(args, message, client) {
-  const arg = args.shift();
-  if (!arg) {
-    help.handle(args, message, client);
-    return;
-  }
-  const handler = arg.toLowerCase();
+  const handler = (args.shift() || "").toLowerCase();
 
   if (!canDoCommand(handler, message)) {
     const notAllowedMsg = `You are not allowed to use the command \`${handler}\`.`;

--- a/src/commands/config/handler.js
+++ b/src/commands/config/handler.js
@@ -27,7 +27,12 @@ const canDoCommand = (command, message) => {
 };
 
 exports.handle = function(args, message, client) {
-  const handler = args.shift().toLowerCase();
+  const arg = args.shift();
+  if (!arg) {
+    help.handle(args, message, client);
+    return;
+  }
+  const handler = arg.toLowerCase();
 
   if (!canDoCommand(handler, message)) {
     const notAllowedMsg = `You are not allowed to use the command \`${handler}\`.`;


### PR DESCRIPTION
Now instead of crashing on incomplete commands bot will display help info instead

More info under issue #50
