### PR TITLE
A simple help configuration change, where !help config and !help bill…

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,7 +1,0 @@
-{
-  "hooks": {
-    "pre-commit": [
-      "npm run fmt:check && npm run lint"
-    ]
-  }
-}

--- a/src/commands/bill/help.js
+++ b/src/commands/bill/help.js
@@ -4,6 +4,6 @@ exports.handle = function(_args, message, _client) {
   help += 'Type `!bill add [bill id]` to add an unkown bill to the watchlist.\n';
   help += 'Type `!bill ignore [state name|state code] [bill #]` to remove a known bill from the watchlist.\n';
   help += 'Type `!bill watch [state name|state code] [bill #]` to add a known bill to the watchlist.\n';
-  help += 'Type `!bill watchlist` to see the entire watchlist.';
+  help += 'Type `!bill list` to see the entire watchlist.';
   message.reply(help);
 };

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,8 +1,19 @@
+const billhelp = require('./bill/help');
+const confighelp = require('./config/help');
+
 exports.handle = function(_args, message, _client) {
-  let help = 'Here is a list of commands:\n';
-  help += 'Type `!ping`.\n';
-  help += 'Type `!help` for general help.\n';
-  help += 'Type `!bill help` for help regarding bills.\n';
-  help += 'Type `!config help` for help regarding configuration.';
-  message.reply(help);
+  if (_args == 'bill') {
+    billhelp.handle(null, message, _client);
+  }
+  else if (_args == 'config') {
+    confighelp.handle(null, message, _client);
+  }
+  else {
+    let help = 'Here is a list of commands:\n';
+    help += 'Type `!ping`.\n';
+    help += 'Type `!help` for general help.\n';
+    help += 'Type `!bill help` for help regarding bills.\n';
+    help += 'Type `!config help` for help regarding configuration.';
+    message.reply(help);
+  }
 };

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,10 +1,10 @@
 const billhelp = require('./bill/help');
 const confighelp = require('./config/help');
 
-exports.handle = function(_args, message, _client) {
-  if (_args === 'bill') {
+exports.handle = function(args, message, _client) {
+  if (args[0] === 'bill') {
     billhelp.handle(null, message, _client);
-  } else if (_args === 'config') {
+  } else if (args[0] === 'config') {
     confighelp.handle(null, message, _client);
   } else {
     let help = 'Here is a list of commands:\n';

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -2,13 +2,11 @@ const billhelp = require('./bill/help');
 const confighelp = require('./config/help');
 
 exports.handle = function(_args, message, _client) {
-  if (_args == 'bill') {
+  if (_args === 'bill') {
     billhelp.handle(null, message, _client);
-  }
-  else if (_args == 'config') {
+  } else if (_args === 'config') {
     confighelp.handle(null, message, _client);
-  }
-  else {
+  } else {
     let help = 'Here is a list of commands:\n';
     help += 'Type `!ping`.\n';
     help += 'Type `!help` for general help.\n';


### PR DESCRIPTION
… will be available, also !bill watchlist is now !bill list

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" when a task is done) -->

This basically changes some help commands to use !help config and !help bill as secondary aliases.

Not tested yet!

- All acceptance criteria are met.
- [x] Functional, clean (and documented if necessary) code.
- [ ] Complete unit and end-to-end test coverage for your feature.
